### PR TITLE
Ability to manually trigger builds

### DIFF
--- a/.github/workflows/ReBarDxe.yml
+++ b/.github/workflows/ReBarDxe.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
+
 env:
   TARGET: RELEASE
   TARGET_ARCH: X64

--- a/.github/workflows/ReBarState.yml
+++ b/.github/workflows/ReBarState.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
At the moment, the github workflows only trigger upon a push. Occasionally, it's nice to have the ability to manually trigger builds. 

For example, if our last push was a long time ago, the uploaded artifacts will have been destroyed; but with a manual build, we can grab the artifacts again.