### PR TITLE
Fix compilation errors in linux

### DIFF
--- a/ReBarState/ReBarState.cpp
+++ b/ReBarState/ReBarState.cpp
@@ -13,6 +13,7 @@ SPDX-License-Identifier: MIT
 #include <unistd.h>
 #include <linux/fs.h>
 #include <sys/ioctl.h>
+#include <cstdint>
 #endif
 
 #define QUOTE(x) #x


### PR DESCRIPTION
cmake errors out during linux build: 
---> ReBarState.cpp:89:9: error: ‘uint32_t’ does not name a type

This fixes it and compiles successfully.
Tested with cmake version 3.28.3 on Linux Mint